### PR TITLE
Add hope selection modal for archiving tasks and fix styling issues

### DIFF
--- a/src/components/Done.tsx
+++ b/src/components/Done.tsx
@@ -1,15 +1,16 @@
 import styled from "styled-components"
-import { Done as TypeDone } from "../types"
-import { CircleButton, ContentWrapper, Task, TaskContents, TaskNameContainer, TopRightCorner } from "./ui"
+import { Hope, Done as TypeDone } from "../types"
+import { CircleButton, ContentWrapper, ModalContainer, ModalOverlay, Task, TaskContents, TaskNameContainer, TextButton, TopRightCorner } from "./ui"
 import { useContext, useState } from "react"
 import { convertHMStoMilliseconds, convertMillisecondsToHMS } from "../utils"
 import EditMarkdownModal from "./EditMardownModal"
 import { Draggable, DraggableProvided } from "react-beautiful-dnd"
-import { Value } from "./ui/Form"
+import { Label, Value } from "./ui/Form"
 import { Archive, X } from "lucide-react"
 import { TasksContext } from "../context/tasksContext"
 import MyCodeMirrorComponent from "./MyCodeMirrorComponent"
 import ReactMarkdown from 'react-markdown';
+import { HopesContext } from "../context/hopesContext"
 
 interface Props {
   index: number;
@@ -27,6 +28,9 @@ export default function Done({ index, task }: Props) {
   const [estimatedDurationHMS, setEstimatedDurationHMS] = useState(convertMillisecondsToHMS(task.estimatedDuration));
   const [isEditingElapsedDuration, setIsEditingElapsedDuration] = useState(false);
   const [elapsedDurationHMS, setElapsedDurationHMS] = useState(convertMillisecondsToHMS(task.timestampSum));
+  const [showSelectHopeModal, setShowSelectHopeModal] = useState(false);
+  const [selectedHopeName, setSelectedHopeName] = useState('none')
+  const { hopes, appendTask } = useContext(HopesContext)
 
   const handleSaveTaskName = (value: string) => {
     setTaskName(value)
@@ -78,6 +82,26 @@ export default function Done({ index, task }: Props) {
     })
   }
 
+  const handleClickArhiveBtn = () => {
+    if (hopes.length === 0) {
+      appendTaskToHope(selectedHopeName, task.key)
+    } else {
+      setShowSelectHopeModal(true)
+    }
+  }
+
+  const appendTaskToHope = (hopeName: string, taskKey: string) => {
+    doneToArchive(taskKey)
+    if (hopeName !== 'none') {
+      appendTask(hopeName, taskKey)
+    }
+  }
+
+  const handleCancelSelectHope = () => {
+    setShowSelectHopeModal(false)
+    setSelectedHopeName('none')
+  }
+
   return (
     <>
       <Draggable draggableId={task.key} index={index}>
@@ -109,7 +133,7 @@ export default function Done({ index, task }: Props) {
                   </ContentWrapper>
                 </CircleButton>
                 <CircleButton>
-                  <ContentWrapper onClick={() => doneToArchive(task.key)}>
+                  <ContentWrapper onClick={handleClickArhiveBtn}>
                     <Archive size={20} />
                   </ContentWrapper>
                 </CircleButton>
@@ -141,11 +165,67 @@ export default function Done({ index, task }: Props) {
           </Task>
         )}
       </Draggable>
-      {showModal && <EditMarkdownModal task={task} setShowModal={setShowModal} />
-      }
+      {showModal && <EditMarkdownModal task={task} setShowModal={setShowModal} />}
+      {showSelectHopeModal && <ModalOverlay onClick={handleCancelSelectHope}>
+        <ModalContainer onClick={(e) => e.stopPropagation()}>
+          <Form>
+            <Select
+              name="hope"
+              id="hope"
+              value={selectedHopeName}
+              onChange={(e) => setSelectedHopeName(e.target.value)}
+            >
+              {
+                ([
+                  {
+                    name: 'none',
+                    markdownContent: '',
+                    parentName: null,
+                    taskOrder: []
+                  },
+                  ...hopes
+                ] as Hope[])
+                  .map(hope => <option key={hope.name} value={hope.name}>{hope.name}</option>)}
+            </Select>
+            <ActionsContainer>
+              <TextButton $counterSecondary
+                onClick={handleCancelSelectHope}
+              >Cancel</TextButton>
+              <TextButton $counter
+                onClick={() => appendTaskToHope(selectedHopeName, task.key)}
+              >Archive</TextButton>
+            </ActionsContainer>
+          </Form>
+        </ModalContainer>
+      </ModalOverlay>}
     </>
   )
 }
+
+const ActionsContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+  gap: 1em;
+`
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding: 1em;
+  `
+
+const Select = styled.select`
+  width: 100%;
+  height: 100%;
+  padding: 1em;
+  border: none;
+  background-color: #f1f1f1;
+  font-size: 1em;
+  color: black;
+  border-radius: 5px;
+  `
 
 const CodeMirrorContainer = styled.div`
   color: black;

--- a/src/components/HopeTree.tsx
+++ b/src/components/HopeTree.tsx
@@ -35,7 +35,7 @@ export default function HopeTree({ hope }: HopeTreeProps) {
     return (
       <>
         <NodeGroup>
-          <NodeCircle r={10} onClick={handleClickCircle} isSelected={selectedHope === nodeDatum.name} />
+          <NodeCircle r={10} onClick={handleClickCircle} $isSelected={selectedHope === nodeDatum.name} />
           <foreignObject x={-50} y={10} width={100} height={120}>
             <NodeInfoContainer onClick={() => selectHope(nodeDatum.name)}>
               <NodeName>{nodeDatum.name}</NodeName>
@@ -126,8 +126,8 @@ const NodeGroup = styled.g`
   cursor: pointer;
 `;
 
-const NodeCircle = styled.circle<{ isSelected: boolean }>`
-  fill: ${props => props.isSelected ? "#c0c0c0" : "#fff"};
+const NodeCircle = styled.circle<{ $isSelected: boolean }>`
+  fill: ${props => props.$isSelected ? "#c0c0c0" : "#fff"};
   stroke: #000;
   stroke-width: 1.5px;
 `;

--- a/src/context/hopesContext.ts
+++ b/src/context/hopesContext.ts
@@ -10,6 +10,7 @@ interface HopeContextType {
   deleteHope: (name: string) => void;
   selectedHope: string;
   selectHope: (name: string) => void;
+  appendTask: (hopeName: string, taskKey: string) => void;
 }
 
 export const HopesContext = createContext<HopeContextType>({} as HopeContextType);

--- a/src/context/hopesContextProvider.tsx
+++ b/src/context/hopesContextProvider.tsx
@@ -54,6 +54,16 @@ export default function HopesContextProvider({ children }: HopesContextProviderP
     setSelectedHope(name)
   }
 
+  const appendTask = (hopeName: string, taskKey: string) => {
+    const newHopes = hopes.map(hope => {
+      if (hope.name === hopeName) {
+        return { ...hope, taskOrder: [...hope.taskOrder, taskKey] }
+      }
+      return hope
+    })
+    setHopes(newHopes)
+  }
+
   const value = {
     hopes,
     setHopes,
@@ -63,6 +73,7 @@ export default function HopesContextProvider({ children }: HopesContextProviderP
     hopeTree,
     selectedHope,
     selectHope,
+    appendTask,
   }
 
   return (

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -5,7 +5,7 @@ import { useContext, useEffect } from "react"
 import { TasksContext } from "../context/tasksContext"
 
 export function useTasks() {
-  const { setData } = useContext(TasksContext)
+  const { data: currentData, setData } = useContext(TasksContext)
   const { isLoading, error, data, isSuccess } = useQuery({
     queryKey: ['tasks'],
     queryFn: async () => {
@@ -48,7 +48,7 @@ export function useTasks() {
   })
 
   useEffect(() => {
-    if (!data || Object.keys(data.tasks || {}).length !== 0) return
+    if (!data || Object.keys(currentData.tasks || {}).length !== 0) return
     setData(data)
   }, [isSuccess])
 


### PR DESCRIPTION
 This commit introduces the following changes:

 - A modal for selecting a hope when archiving a task has been added. This allows users to associate an archived task with a specific hope.
 - The `handleClickArhiveBtn` function has been implemented to handle the display of the hope selection modal when there are hopes available.
 - The `appendTaskToHope` function has been created to handle the logic of appending a task to a hope and archiving it.
 - The `handleCancelSelectHope` function allows users to cancel the hope selection process.
 - The `ActionsContainer`, `Form`, and `Select` styled components have been added for the modal's UI.
 - The `NodeCircle` styled component has been updated to use the `` prop for conditional styling, fixing a previous issue with the prop naming convention.
 - The `HopesContext` now includes the `appendTask` function to support appending tasks to hopes.
 - The `useTasks` hook has been corrected to use `currentData` instead of `data` to prevent unnecessary updates when the data hasn't changed.

 These enhancements improve the user experience by providing a more intuitive way to organize tasks within hopes and ensure the UI is consistent and functional.