### PR TITLE
feature: Enhance task deletion and column saving logic

### DIFF
--- a/src/context/tasksContextProvider.tsx
+++ b/src/context/tasksContextProvider.tsx
@@ -79,7 +79,8 @@ export default function TasksContextProvider({ children }: TasksContextProviderP
       columns
     }
 
-    mutateDeleteTask.mutate(newdata)
+    mutateDeleteTask.mutate({ oldData: data, newData: newdata })
+    mutateSaveColumn.mutate(newdata)
     setData(newdata)
     return isDayEmpty
   }

--- a/src/utils/saveData.ts
+++ b/src/utils/saveData.ts
@@ -109,9 +109,9 @@ export async function saveColumns(data: Data) {
     }
   }
 }
-export async function removeNoLinkedTasks(data: Data) {
-  const keysFromAllColumns = getKeysFromAllColumns(data)
-  const taskKeys = Object.keys(data.tasks)
+export async function removeNoLinkedTasks({ oldData, newData }: { oldData: Data, newData: Data }) {
+  const keysFromAllColumns = getKeysFromAllColumns(newData)
+  const taskKeys = Object.keys(oldData.tasks)
   for (const key of taskKeys) {
     if (!keysFromAllColumns.includes(key)) {
       await removeTaskByKey(key)


### PR DESCRIPTION
 This commit introduces a more robust handling of task deletions by updating the `mutateDeleteTask` to accept both old and new data states. Additionally, it ensures that column data is saved upon task deletion by
 invoking `mutateSaveColumn` with the new data. The `removeNoLinkedTasks` function has been refactored to work with the updated structure, improving the integrity of task removal.