### PR TITLE
feature: Integrate add and delete hope mutations with react-query

### DIFF
--- a/src/context/hopesContextProvider.tsx
+++ b/src/context/hopesContextProvider.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { HopesContext } from "./hopesContext";
 import { Hope, HopeMapValue } from "../types";
 import { buildHopeTree } from "../utils/hopes";
+import { useMutation } from "@tanstack/react-query";
+import { createHope, deleteHope as deleteHopeService, fetchHopeByName } from "../services/hopes";
 
 interface HopesContextProviderProps {
   children: React.ReactNode
@@ -14,13 +16,27 @@ export default function HopesContextProvider({ children }: HopesContextProviderP
   const hopesNames = hopes.map(hope => hope.name)
   const hopeTree = buildHopeTree(hopes)
 
+  const mutateAddHope = useMutation({
+    mutationFn: createHope
+  })
+
+  const mutateDeleteHope = useMutation({
+    mutationFn: async (name: string) => {
+      const hope = await fetchHopeByName(name)
+      if (!hope) return
+      return deleteHopeService(hope.id)
+    }
+  })
+
   const addHope = (newHope: Hope) => {
+    mutateAddHope.mutate(newHope)
     setHopes(prevHopes => [...prevHopes, newHope])
   }
 
   const deleteHope = (name: string) => {
     const hopeNames = collectHopeNames(name)
     const newHopes = hopes.filter(hope => !hopeNames.includes(hope.name))
+    mutateDeleteHope.mutate(name)
     setHopes(newHopes)
   }
 

--- a/src/services/hopes.ts
+++ b/src/services/hopes.ts
@@ -11,3 +11,16 @@ export async function createHope(payload: CreateHopePayload) {
   const { data } = await api.post("/hopes", payload);
   return data as { id: number }
 }
+
+export async function deleteHope(hopeId: number) {
+  await api.delete(`/hopes/${hopeId}`);
+}
+
+export async function fetchHopeByName(name: string) {
+  try {
+    const { data } = await api.get(`/hopes/name/${name}`);
+    return data as HopeResponse;
+  } catch (error) {
+    return null;
+  }
+}


### PR DESCRIPTION
 - Utilize `useMutation` hook from `@tanstack/react-query` for adding and deleting hopes.
 - Implement `mutateAddHope` and `mutateDeleteHope` functions within `HopesContextProvider`.
 - Add service functions `createHope`, `deleteHope`, and `fetchHopeByName` in `hopes.ts`.
 - Ensure deletion logic checks for hope existence before attempting to delete.