### PR TITLE
feat: Add markdown content update functionality to HopesContext

### DIFF
--- a/src/context/hopesContext.ts
+++ b/src/context/hopesContext.ts
@@ -12,6 +12,7 @@ interface HopeContextType {
   selectHope: (name: string) => void;
   appendTask: (hopeName: string, taskKey: string) => void;
   isPending: boolean;
+  updateMarkdownContent: (value: string) => void;
 }
 
 export const HopesContext = createContext<HopeContextType>({} as HopeContextType);

--- a/src/hooks/hopes/useHopes.ts
+++ b/src/hooks/hopes/useHopes.ts
@@ -17,7 +17,7 @@ export function useHopes() {
           name: hope.name,
           markdownContent: hope.markdown_content,
           parentName: hope.parent_name,
-          taskOrder: JSON.parse(hope.task_order),
+          taskOrder: JSON.parse(hope.task_order)
         }
         return formattedHope
       })

--- a/src/routes/hopes.tsx
+++ b/src/routes/hopes.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 export default function Hopes() {
   const [isEditing, setIsEditing] = useState(false)
   useHopes()
-  const { hopes, setHopes, hopeTree, selectedHope } = useContext(HopesContext)
+  const { hopes, hopeTree, selectedHope, updateMarkdownContent } = useContext(HopesContext)
   const { showModal, setShowModal } = useContext(ModalHopeContext)
   const getSelectedHopeContent = () => {
     if (!selectedHope) return ''
@@ -22,13 +22,7 @@ export default function Hopes() {
   const initialValue = getSelectedHopeContent()
 
   const handleSave = (value: string) => {
-    const newHopes = hopes.map((hope) => {
-      if (hope.name === selectedHope) {
-        return { ...hope, markdownContent: value }
-      }
-      return hope
-    })
-    setHopes(newHopes)
+    updateMarkdownContent(value)
     setIsEditing(false)
   }
 

--- a/src/services/hopes.ts
+++ b/src/services/hopes.ts
@@ -1,5 +1,5 @@
 import api from ".";
-import { CreateHopePayload, HopeResponse } from "../types";
+import { CreateHopePayload, HopeResponse, UpdateHopePayload } from "../types";
 
 
 export async function fetchHopes() {
@@ -20,6 +20,14 @@ export async function fetchHopeByName(name: string) {
   try {
     const { data } = await api.get(`/hopes/name/${name}`);
     return data as HopeResponse;
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function updateHope(payload: UpdateHopePayload) {
+  try {
+    await api.put(`/hopes`, payload);
   } catch (error) {
     return null;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,13 @@ export interface CreateHopePayload {
   parent_name?: string | null
 }
 
+export interface UpdateHopePayload {
+  name: string
+  parent_name?: string | null
+  markdown_content?: string
+  task_order?: string
+}
+
 export interface HopeMapValue extends Hope {
   children: HopeMapValue[]
   attributes: {


### PR DESCRIPTION
 This commit introduces the ability to update the markdown content of a hope within the
 HopesContext. A new function `updateMarkdownContent` has been added to the context, along wit
 the necessary mutation function in the HopesContextProvider. The `hopesContextProvider.tsx` n
 includes the logic to handle the markdown content update through the `updateHope` service. Th
 `hopes.tsx` route has been refactored to use the new context function for saving changes.
 Additionally, the `useHopes` hook and `hopes` service have been updated to support the new
 functionality.