### PR TITLE
feat: Integrate editor context for HopeTree component

### DIFF
--- a/src/components/FormEditHope.tsx
+++ b/src/components/FormEditHope.tsx
@@ -1,0 +1,94 @@
+import styled from "styled-components";
+import { CircleButton, ContentWrapper, FormField, FormFields, Input, InputWrapper, Label, ModalCloseCorner, ModalContainer, ModalOverlay, TextButton } from "./ui";
+import { useContext } from "react";
+import { EditorHopeContext } from "../context/editorHopeContext";
+
+interface Props { }
+
+export default function FormEditHope({ }: Props) {
+  const {
+    updateHope,
+    isValid,
+    inputName,
+    setInputName,
+    initModal,
+    otherHopes,
+    selectedKey,
+    setSelectedKey,
+    setShowEditorHope } = useContext(EditorHopeContext)
+
+  return (
+    <ModalOverlay>
+      <ModalContainer>
+        <ModalCloseCorner>
+          <CircleButton $ghost onClick={() => setShowEditorHope(false)}>
+            <ContentWrapper $size="1.5em">
+              &#10006;
+            </ContentWrapper>
+          </CircleButton>
+        </ModalCloseCorner>
+        <form onSubmit={updateHope}>
+          <h2>Edit Hope</h2>
+          <FormFields style={{ margin: '3em 0 2em 0' }}>
+            <FormField>
+              <Label htmlFor="task">Hope</Label>
+              <InputWrapper>
+                <Input type="text" id="hope" name="hope" value={inputName} onChange={(e) => setInputName(e.target.value)} />
+              </InputWrapper>
+            </FormField>
+            <FormField>
+              <Label htmlFor="parent">Parent</Label>
+              <Select
+                id="parent"
+                name="parent"
+                value={selectedKey}
+                onChange={(e) => setSelectedKey(e.target.value)}
+              >
+                <option value="">No Parent</option>
+                {otherHopes.map((hope) => (
+                  <option key={hope.key} value={hope.key}>
+                    {hope.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          </FormFields>
+          <FormActions>
+            <TextButton
+              $counterSecondary
+              type="button"
+              onClick={() => initModal(false)}
+            >
+              <ContentWrapper $weight="bold">
+                Cancel
+              </ContentWrapper>
+            </TextButton>
+            <TextButton $counter disabled={!isValid} type="submit">
+              <ContentWrapper $weight="bold">
+                Save
+              </ContentWrapper>
+            </TextButton>
+          </FormActions>
+        </form>
+      </ModalContainer>
+    </ModalOverlay>
+  )
+}
+
+const Select = styled.select`
+  width: 100%;
+  height: 100%;
+  padding: 0.5em;
+  border: none;
+  background-color: #f1f1f1;
+  font-size: 1em;
+  color: black;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  `
+const FormActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1em;
+  padding-top: 1em;
+  `

--- a/src/components/HopeTree.tsx
+++ b/src/components/HopeTree.tsx
@@ -5,6 +5,7 @@ import { useContext, useRef } from "react";
 import { ModalHopeContext } from "../context/modalHopeContext";
 import { BookOpen, CircleMinus, CirclePlus } from "lucide-react";
 import { HopesContext } from "../context/hopesContext";
+import { EditorHopeContext } from "../context/editorHopeContext";
 
 interface HopeTreeProps {
   hope: HopeMapValue;
@@ -14,6 +15,10 @@ export default function HopeTree({ hope }: HopeTreeProps) {
   const treeRef = useRef<Tree>(null);
   const { initModal } = useContext(ModalHopeContext)
   const { deleteHope, selectedHope, selectHope } = useContext(HopesContext)
+  const { setShowEditorHope } = useContext(EditorHopeContext)
+
+
+
   const renderCustomNodeElement: RenderCustomNodeElementFn = ({ nodeDatum, toggleNode }: any) => {
     const handleClickCircle = (e: React.MouseEvent<SVGCircleElement, MouseEvent>) => {
       e.stopPropagation();
@@ -30,6 +35,10 @@ export default function HopeTree({ hope }: HopeTreeProps) {
       deleteHope(nodeDatum.key);
     }
 
+    const handleShowModal = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.stopPropagation();
+      setShowEditorHope(true)
+    }
 
     return (
       <>
@@ -52,14 +61,13 @@ export default function HopeTree({ hope }: HopeTreeProps) {
                 <NodeButton onClick={handleDeleteHope}>
                   <CircleMinus size={16} />
                 </NodeButton>
-                <NodeButton>
+                <NodeButton onClick={handleShowModal}>
                   <BookOpen size={16} />
                 </NodeButton>
               </NodeButtonGroup>
             </NodeInfoContainer>
           </foreignObject>
         </NodeGroup>
-
       </>
     );
   };

--- a/src/context/editorHopeContext.ts
+++ b/src/context/editorHopeContext.ts
@@ -1,0 +1,16 @@
+import React, { createContext } from 'react';
+
+interface EditorHopeContextType {
+  showEditorHope: boolean;
+  setShowEditorHope: React.Dispatch<React.SetStateAction<boolean>>;
+  inputName: string;
+  setInputName: React.Dispatch<React.SetStateAction<string>>;
+  otherHopes: { key: string; name: string }[];
+  selectedKey: string;
+  setSelectedKey: React.Dispatch<React.SetStateAction<string>>;
+  initModal: (showModal?: boolean) => void;
+  isValid: boolean;
+  updateHope: () => void;
+}
+
+export const EditorHopeContext = createContext<EditorHopeContextType>({} as EditorHopeContextType);

--- a/src/context/editorHopeContextProvider.tsx
+++ b/src/context/editorHopeContextProvider.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { EditorHopeContext } from "./editorHopeContext";
+
+interface EditorHopeContextProviderProps {
+  children: React.ReactNode
+}
+
+
+export default function EditorHopeContextProvider({ children }: EditorHopeContextProviderProps) {
+  const [showEditorHope, setShowEditorHope] = useState(false)
+  const [inputName, setInputName] = useState('')
+  const otherHopes = [
+    { key: '1', name: 'Hope 1' },
+    { key: '2', name: 'Hope 2' },
+    { key: '3', name: 'Hope 3' },
+  ]
+  const [selectedKey, setSelectedKey] = useState('1')
+  const isValid = inputName.length > 0
+
+  const initModal = (showModal = false) => {
+    setInputName('')
+    setSelectedKey('1')
+    setShowEditorHope(showModal)
+  }
+
+  const updateHope = () => {
+    console.log({ inputName, selectedKey })
+  }
+
+
+  const value = {
+    showEditorHope,
+    setShowEditorHope,
+    inputName,
+    setInputName,
+    otherHopes,
+    selectedKey,
+    setSelectedKey,
+    initModal,
+    isValid,
+    updateHope
+  }
+
+  return <EditorHopeContext.Provider value={value}>
+    {children}
+  </EditorHopeContext.Provider>
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import Todos from "./routes/todos.tsx"
 import Hopes from "./routes/hopes.tsx"
 import HopesContextProvider from './context/hopesContextProvider.tsx'
 import ModalHopeContextProvider from './context/modalHopeContextProvider.tsx'
+import EditorHopeContextProvider from './context/editorHopeContextProvider.tsx'
 
 const router = createBrowserRouter([
   {
@@ -35,16 +36,18 @@ const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <QueryClientProvider client={queryClient}>
-    <TasksContextProvider>
-      <HopesContextProvider>
-        <DayContextProvider>
-          <EditorContextProvider>
-            <ModalHopeContextProvider>
-              <RouterProvider router={router} />
-            </ModalHopeContextProvider>
-          </EditorContextProvider>
-        </DayContextProvider>
-      </HopesContextProvider>
-    </TasksContextProvider>
+    <EditorHopeContextProvider>
+      <TasksContextProvider>
+        <HopesContextProvider>
+          <DayContextProvider>
+            <EditorContextProvider>
+              <ModalHopeContextProvider>
+                <RouterProvider router={router} />
+              </ModalHopeContextProvider>
+            </EditorContextProvider>
+          </DayContextProvider>
+        </HopesContextProvider>
+      </TasksContextProvider>
+    </EditorHopeContextProvider>
   </QueryClientProvider>
 )

--- a/src/routes/hopes.tsx
+++ b/src/routes/hopes.tsx
@@ -7,12 +7,15 @@ import HopeTree from "../components/HopeTree"
 import { ModalHopeContext } from "../context/modalHopeContext"
 import MyCodeMirrorComponent from "../components/MyCodeMirrorComponent"
 import ReactMarkdown from 'react-markdown';
+import { EditorHopeContext } from "../context/editorHopeContext"
+import FormEditHope from "../components/FormEditHope"
 
 export default function Hopes() {
   const [isEditing, setIsEditing] = useState(false)
   useHopes()
   const { hopes, hopeTree, selectedHope, updateMarkdownContent } = useContext(HopesContext)
   const { showModal, setShowModal } = useContext(ModalHopeContext)
+  const { showEditorHope } = useContext(EditorHopeContext)
   const getSelectedHopeContent = () => {
     if (!selectedHope) return ''
     const hope = hopes.find((hope) => hope.name === selectedHope)
@@ -46,12 +49,7 @@ export default function Hopes() {
     <>
       <Container>
         <TreeContainer>
-          {hopeTree.map((hope) => (
-            <>
-              <HopeTree
-                hope={hope} key={hope.key} />
-            </>
-          ))}
+          {hopeTree.map((hope) => <HopeTree hope={hope} key={hope.key} />)}
         </TreeContainer>
         {selectedHope && <HopeContaniner onClick={toggleEdit}>
           {isEditing ?
@@ -65,6 +63,7 @@ export default function Hopes() {
         </HopeContaniner>}
       </Container>
       {showModal && <FormAddHope setShowModal={setShowModal} />}
+      {showEditorHope && <FormEditHope />}
     </>
   )
 }


### PR DESCRIPTION
 - Add EditorHopeContext to HopeTree component for managing editor state
 - Implement handleShowModal function to toggle editor visibility
 - Include EditorHopeContextProvider in the main app wrapper for context availability
 - Refactor HopeTree component to use new context and handle editor modal
 - Simplify HopeTree mapping in hopes.tsx
 - Add FormEditHope component to Hopes route when editor state is active