### PR TITLE
feat: Update hope editing functionality and service endpoint

### DIFF
--- a/src/components/FormEditHope.tsx
+++ b/src/components/FormEditHope.tsx
@@ -28,8 +28,7 @@ export default function FormEditHope({ }: Props) {
           </CircleButton>
         </ModalCloseCorner>
         <form onSubmit={updateHope}>
-          {/* <h2>Edit Hope</h2> */}
-          <h2>{selectedKey}</h2>
+          <h2>Edit Hope</h2>
           <FormFields style={{ margin: '3em 0 2em 0' }}>
             <FormField>
               <Label htmlFor="task">Hope</Label>

--- a/src/context/editorHopeContext.ts
+++ b/src/context/editorHopeContext.ts
@@ -10,7 +10,7 @@ interface EditorHopeContextType {
   setSelectedKey: React.Dispatch<React.SetStateAction<string>>;
   initModal: (showModal?: boolean) => void;
   isValid: boolean;
-  updateHope: () => void;
+  updateHope: (e: React.FormEvent<HTMLFormElement>) => void;
   key: string;
   setKey: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/src/context/editorHopeContextProvider.tsx
+++ b/src/context/editorHopeContextProvider.tsx
@@ -1,6 +1,10 @@
 import { useContext, useState } from "react";
 import { EditorHopeContext } from "./editorHopeContext";
 import { HopesContext } from "./hopesContext";
+import { Hope } from "../types";
+import { useMutation } from "@tanstack/react-query";
+import { updateHope as updateHopeService } from "../services/hopes";
+
 
 interface EditorHopeContextProviderProps {
   children: React.ReactNode
@@ -8,11 +12,15 @@ interface EditorHopeContextProviderProps {
 
 
 export default function EditorHopeContextProvider({ children }: EditorHopeContextProviderProps) {
+  const mutateHope = useMutation({
+    mutationFn: updateHopeService,
+  })
+
   const [showEditorHope, setShowEditorHope] = useState(false)
   const [inputName, setInputName] = useState('')
   const [key, setKey] = useState('')
   const [selectedKey, setSelectedKey] = useState('')
-  const { hopes } = useContext(HopesContext)
+  const { hopes, setHopes } = useContext(HopesContext)
   const otherHopes = hopes
     .map(hope => ({ key: hope.key, name: hope.name }))
     .filter(hope => hope.key !== key)
@@ -24,8 +32,34 @@ export default function EditorHopeContextProvider({ children }: EditorHopeContex
     setShowEditorHope(showModal)
   }
 
-  const updateHope = () => {
-    console.log({ inputName, selectedKey })
+  const updateHope = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    if (!isValid) return
+
+    const updatedHope: Partial<Hope> = {
+      name: inputName,
+      key,
+      parentKey: selectedKey ? selectedKey : null,
+    }
+
+    setHopes(prevHopes => {
+      return prevHopes.map(hope => {
+        if (hope.key === key) {
+          const newHope = { ...hope, ...updatedHope }
+          const updateHopePayload = {
+            key: newHope.key,
+            name: newHope.name,
+            parent_key: newHope.parentKey ? newHope.parentKey : '',
+          }
+          mutateHope.mutate(updateHopePayload)
+          return newHope
+        }
+        return hope
+      })
+    })
+
+    initModal(false)
   }
 
 
@@ -41,7 +75,7 @@ export default function EditorHopeContextProvider({ children }: EditorHopeContex
     isValid,
     updateHope,
     key,
-    setKey
+    setKey,
   }
 
   return <EditorHopeContext.Provider value={value}>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,8 +2,8 @@ import axios from "axios";
 
 
 const api = axios.create({
-  baseURL: "http://44.201.114.25:8000",
-  // baseURL: "http://localhost:8000",
+  // baseURL: "http://44.201.114.25:8000",
+  baseURL: "http://localhost:8000",
   withCredentials: true
 });
 


### PR DESCRIPTION
 - Re-enable the "Edit Hope" title in the form header.
 - Modify the updateHope function to handle form submission and prevent action if the form is invalid.
 - Implement form submission logic to update hope details using the react-query mutation.
 - Change the API base URL to the local development server.