### PR TITLE
debug: Add initialValue to HopesContext and refactor initial value logic

### DIFF
--- a/src/context/hopesContext.ts
+++ b/src/context/hopesContext.ts
@@ -13,6 +13,7 @@ interface HopeContextType {
   appendTask: (hopeName: string, taskKey: string) => void;
   isPending: boolean;
   updateMarkdownContent: (value: string) => void;
+  initialValue: string;
 }
 
 export const HopesContext = createContext<HopeContextType>({} as HopeContextType);

--- a/src/context/hopesContextProvider.tsx
+++ b/src/context/hopesContextProvider.tsx
@@ -16,6 +16,14 @@ export default function HopesContextProvider({ children }: HopesContextProviderP
   const hopesKeys = hopes.map(hope => hope.key)
   const hopeTree = buildHopeTree(hopes)
 
+  const getSelectedHopeContent = () => {
+    if (!selectedHope) return ''
+    const hope = hopes.find((hope) => hope.key === selectedHope)
+    if (!hope) return ''
+    return hope.markdownContent
+  }
+  const initialValue = getSelectedHopeContent()
+
   const mutateAddHope = useMutation({
     mutationFn: createHope
   })
@@ -123,7 +131,8 @@ export default function HopesContextProvider({ children }: HopesContextProviderP
     selectHope,
     appendTask,
     isPending,
-    updateMarkdownContent
+    updateMarkdownContent,
+    initialValue
   }
 
   return (

--- a/src/routes/hopes.tsx
+++ b/src/routes/hopes.tsx
@@ -13,16 +13,9 @@ import FormEditHope from "../components/FormEditHope"
 export default function Hopes() {
   const [isEditing, setIsEditing] = useState(false)
   useHopes()
-  const { hopes, hopeTree, selectedHope, updateMarkdownContent } = useContext(HopesContext)
+  const { hopes, hopeTree, selectedHope, updateMarkdownContent, initialValue } = useContext(HopesContext)
   const { showModal, setShowModal } = useContext(ModalHopeContext)
   const { showEditorHope } = useContext(EditorHopeContext)
-  const getSelectedHopeContent = () => {
-    if (!selectedHope) return ''
-    const hope = hopes.find((hope) => hope.name === selectedHope)
-    if (!hope) return ''
-    return hope.markdownContent
-  }
-  const initialValue = getSelectedHopeContent()
 
   const handleSave = (value: string) => {
     updateMarkdownContent(value)


### PR DESCRIPTION
 - Add `initialValue` property to `HopeContextType` interface and `HopesContext` to store the initial content of the selected hope.
 - Refactor `HopesContextProvider` to compute `initialValue` using a new function `getSelectedHopeContent`.
 - Remove redundant `getSelectedHopeContent` and `initialValue` computation from `Hopes` component.