### PR TITLE
debug: Ensure tasks array is populated with existing tasks only

### DIFF
--- a/src/context/tasksContextProvider.tsx
+++ b/src/context/tasksContextProvider.tsx
@@ -277,7 +277,12 @@ export default function TasksContextProvider({ children }: TasksContextProviderP
   function getTasksByColumnKey(columnKey: string) {
     const column = data.columns[columnKey]
     if (!column) return []
-    return column.taskIds.map((taskKey) => data.tasks[taskKey])
+    const tasks = []
+    for (const taskKey of column.taskIds) {
+      const task = data.tasks[taskKey]
+      if (task) tasks.push(task)
+    }
+    return tasks
   }
 
   function moveTaskToOtherColumn(taskKey: string, destinationColumnKey: string) {


### PR DESCRIPTION
 This commit modifies the getTasksByColumnKey function to check for the existence of a task before addin
 it to the tasks array. This prevents potential issues where non-existent task references could lead to
 errors or empty entries in the tasks array.